### PR TITLE
fix hash link for intoto entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
 				"caniuse-lite": "^1.0.30001441",
 				"eslint": "8.10.0",
 				"eslint-config-next": "13.0.0",
-				"prettier": "^2.8.2",
+				"prettier": "^3.0.0",
 				"typescript": "4.6.2"
 			},
 			"engines": {
@@ -4478,15 +4478,15 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.5.tgz",
-			"integrity": "sha512-3gzuxrHbKUePRBB4ZeU08VNkUcqEHaUaouNt0m7LGP4Hti/NuB07C7PPTM/LkWqXoJYJn2McEo5+kxPNrtQkLQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+			"integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
 			"dev": true,
 			"bin": {
-				"prettier": "bin-prettier.js"
+				"prettier": "bin/prettier.cjs"
 			},
 			"engines": {
-				"node": ">=10.13.0"
+				"node": ">=14"
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
@@ -8743,9 +8743,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.5.tgz",
-			"integrity": "sha512-3gzuxrHbKUePRBB4ZeU08VNkUcqEHaUaouNt0m7LGP4Hti/NuB07C7PPTM/LkWqXoJYJn2McEo5+kxPNrtQkLQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+			"integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
 			"dev": true
 		},
 		"prismjs": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"caniuse-lite": "^1.0.30001441",
 		"eslint": "8.10.0",
 		"eslint-config-next": "13.0.0",
-		"prettier": "^2.8.2",
+		"prettier": "^3.0.0",
 		"typescript": "4.6.2"
 	}
 }

--- a/src/modules/api/context.tsx
+++ b/src/modules/api/context.tsx
@@ -15,7 +15,7 @@ export interface RekorClientContext {
 }
 
 export const RekorClientContext = createContext<RekorClientContext | undefined>(
-	undefined
+	undefined,
 );
 
 export const RekorClientProvider: FunctionComponent<PropsWithChildren<{}>> = ({
@@ -50,7 +50,7 @@ export function useRekorClient(): RekorClient {
 
 export function useRekorBaseUrl(): [
 	RekorClientContext["baseUrl"],
-	RekorClientContext["setBaseUrl"]
+	RekorClientContext["setBaseUrl"],
 ] {
 	const ctx = useContext(RekorClientContext);
 

--- a/src/modules/api/rekor_api.ts
+++ b/src/modules/api/rekor_api.ts
@@ -73,21 +73,21 @@ export function useRekorSearch() {
 					return queryEntries(client, { hash });
 			}
 		},
-		[client]
+		[client],
 	);
 }
 
 async function queryEntries(
 	client: RekorClient,
-	query: SearchIndex
+	query: SearchIndex,
 ): Promise<RekorEntries> {
 	const logIndexes = await client.index.searchIndex({ query });
 
 	const uuidToRetrieve = logIndexes.slice(0, 20);
 	const entries = await Promise.all(
 		uuidToRetrieve.map(entryUuid =>
-			client.entries.getLogEntryByUuid({ entryUuid })
-		)
+			client.entries.getLogEntryByUuid({ entryUuid }),
+		),
 	);
 	return {
 		totalCount: logIndexes.length,

--- a/src/modules/components/Explorer.tsx
+++ b/src/modules/components/Explorer.tsx
@@ -139,15 +139,15 @@ export function Explorer() {
 					},
 				},
 				`/?${formInputs.attribute}=${formInputs.value}`,
-				{ shallow: true }
+				{ shallow: true },
 			);
 		},
-		[router]
+		[router],
 	);
 
 	useEffect(() => {
 		const attribute = Object.keys(router.query).find(key =>
-			isAttribute(key)
+			isAttribute(key),
 		) as Attribute | undefined;
 		const value = attribute && router.query[attribute];
 

--- a/src/modules/components/HashedRekord.tsx
+++ b/src/modules/components/HashedRekord.tsx
@@ -12,7 +12,7 @@ export function HashedRekordViewer({
 	hashedRekord: RekorSchema;
 }) {
 	const certContent = window.atob(
-		hashedRekord.signature.publicKey?.content || ""
+		hashedRekord.signature.publicKey?.content || "",
 	);
 
 	const publicKey = {

--- a/src/modules/components/Intoto.tsx
+++ b/src/modules/components/Intoto.tsx
@@ -29,7 +29,7 @@ export function IntotoViewer({ intoto }: { intoto: IntotoV002Schema }) {
 				sx={{ py: 1 }}
 			>
 				<NextLink
-					href={`/?hash=${intoto.content.hash?.algorithm}:${intoto.content.hash?.value}`}
+					href={`/?hash=${intoto.content.payloadHash?.algorithm}:${intoto.content.payloadHash?.value}`}
 					passHref
 				>
 					<Link>Hash</Link>
@@ -40,7 +40,7 @@ export function IntotoViewer({ intoto }: { intoto: IntotoV002Schema }) {
 				language="text"
 				style={atomDark}
 			>
-				{`${intoto.content.hash?.algorithm}:${intoto.content.hash?.value}`}
+				{`${intoto.content.payloadHash?.algorithm}:${intoto.content.payloadHash?.value}`}
 			</SyntaxHighlighter>
 
 			<Typography

--- a/src/modules/components/SearchForm.tsx
+++ b/src/modules/components/SearchForm.tsx
@@ -140,7 +140,7 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 			pattern: undefined,
 			min: undefined,
 		},
-		inputConfigByAttribute[watchAttribute].rules
+		inputConfigByAttribute[watchAttribute].rules,
 	);
 
 	return (

--- a/src/modules/x509/extensions.ts
+++ b/src/modules/x509/extensions.ts
@@ -23,7 +23,7 @@ function textDecoder(rawExtension: Extension): string {
 
 function utf8StringDecoder(rawExtension: Extension): string {
 	return AsnUtf8StringConverter.fromASN(
-		AsnAnyConverter.toASN(rawExtension.value)
+		AsnAnyConverter.toASN(rawExtension.value),
 	);
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
The "hash" link on page for intoto entries is using the wrong hash value. Intoto entries contain two hash values:

* `hash` is the digest of the entire DSSE envelope.
* `payloadHash` is the digest of the payload contained within the DSSE envelope.

It appears that Rekor is only indexing the `payloadHash` value so it is not possible to look-up an entry by the envelope hash. 

This fix updates the page to show the payload hash and updates the corresponding link to search the Rekor by this value.

<img width="913" alt="image" src="https://github.com/sigstore/rekor-search-ui/assets/398027/86b4b54b-720f-4a63-b111-683e399ea0fa">
