### PR TITLE
support for 'dsse' rekor type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"react-error-boundary": "^3.1.4",
 				"react-hook-form": "^7.31.0",
 				"react-syntax-highlighter": "^15.5.0",
-				"rekor": "^0.0.7",
+				"rekor": "^0.2.0",
 				"sass": "^1.49.9",
 				"sharp": "^0.30.5"
 			},
@@ -4777,9 +4777,9 @@
 			}
 		},
 		"node_modules/rekor": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/rekor/-/rekor-0.0.7.tgz",
-			"integrity": "sha512-xhIBDC+QcsOgfpqe11TecKpFNZjINNBLT1nWa/MRqqMbJKdg8KnWUWbcKk/6iKS5XZ8BY8nAQmabjlrXRw8gzA=="
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/rekor/-/rekor-0.2.0.tgz",
+			"integrity": "sha512-m6CXrk7CR8Qgq0c9nk556lmSDka5faU8H625kgt9uJVCGtP2fT/cfLYT60ZEMbXuQEEuH9M3JcdN7aFh3sFtVw=="
 		},
 		"node_modules/resolve": {
 			"version": "1.22.1",
@@ -8952,9 +8952,9 @@
 			"dev": true
 		},
 		"rekor": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/rekor/-/rekor-0.0.7.tgz",
-			"integrity": "sha512-xhIBDC+QcsOgfpqe11TecKpFNZjINNBLT1nWa/MRqqMbJKdg8KnWUWbcKk/6iKS5XZ8BY8nAQmabjlrXRw8gzA=="
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/rekor/-/rekor-0.2.0.tgz",
+			"integrity": "sha512-m6CXrk7CR8Qgq0c9nk556lmSDka5faU8H625kgt9uJVCGtP2fT/cfLYT60ZEMbXuQEEuH9M3JcdN7aFh3sFtVw=="
 		},
 		"resolve": {
 			"version": "1.22.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"react-error-boundary": "^3.1.4",
 		"react-hook-form": "^7.31.0",
 		"react-syntax-highlighter": "^15.5.0",
-		"rekor": "^0.0.7",
+		"rekor": "^0.2.0",
 		"sass": "^1.49.9",
 		"sharp": "^0.30.5"
 	},

--- a/src/modules/components/DSSE.tsx
+++ b/src/modules/components/DSSE.tsx
@@ -1,0 +1,72 @@
+import { Box, Link, Typography } from "@mui/material";
+import { dump } from "js-yaml";
+import NextLink from "next/link";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { atomDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import { DSSEV001Schema } from "rekor";
+import { decodex509 } from "../x509/decode";
+
+export function DSSEViewer({ dsse }: { dsse: DSSEV001Schema }) {
+	const sig = dsse.signatures?.[0];
+	const certContent = window.atob(sig?.verifier || "");
+
+	const publicKey = {
+		title: "Public Key",
+		content: certContent,
+	};
+	if (certContent.includes("BEGIN CERTIFICATE")) {
+		publicKey.title = "Public Key Certificate";
+		publicKey.content = dump(decodex509(certContent), {
+			noArrayIndent: true,
+			lineWidth: -1,
+		});
+	}
+
+	return (
+		<Box>
+			<Typography
+				variant="h5"
+				sx={{ py: 1 }}
+			>
+				<NextLink
+					href={`/?hash=${dsse.payloadHash?.algorithm}:${dsse.payloadHash?.value}`}
+					passHref
+				>
+					<Link>Hash</Link>
+				</NextLink>
+			</Typography>
+
+			<SyntaxHighlighter
+				language="text"
+				style={atomDark}
+			>
+				{`${dsse.payloadHash?.algorithm}:${dsse.payloadHash?.value}`}
+			</SyntaxHighlighter>
+
+			<Typography
+				variant="h5"
+				sx={{ py: 1 }}
+			>
+				Signature
+			</Typography>
+			<SyntaxHighlighter
+				language="text"
+				style={atomDark}
+			>
+				{sig?.signature || ""}
+			</SyntaxHighlighter>
+			<Typography
+				variant="h5"
+				sx={{ py: 1 }}
+			>
+				{publicKey.title}
+			</Typography>
+			<SyntaxHighlighter
+				language="yaml"
+				style={atomDark}
+			>
+				{publicKey.content}
+			</SyntaxHighlighter>
+		</Box>
+	);
+}

--- a/src/modules/components/Entry.tsx
+++ b/src/modules/components/Entry.tsx
@@ -18,8 +18,9 @@ import { Convert } from "pvtsutils";
 import { ReactNode } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { atomDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
-import { IntotoV002Schema, LogEntry, RekorSchema } from "rekor";
+import { DSSEV001Schema, IntotoV002Schema, LogEntry, RekorSchema } from "rekor";
 import { toRelativeDateString } from "../utils/date";
+import { DSSEViewer } from "./DSSE";
 import { HashedRekordViewer } from "./HashedRekord";
 import { IntotoViewer } from "./Intoto";
 
@@ -128,6 +129,9 @@ export function Entry({ entry }: { entry: LogEntry }) {
 			break;
 		case "intoto":
 			parsed = <IntotoViewer intoto={body.spec as IntotoV002Schema} />;
+			break;
+		case "dsse":
+			parsed = <DSSEViewer dsse={body.spec as DSSEV001Schema} />;
 			break;
 	}
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Support display of "dsse" Rekor entries.

Related: https://github.com/pdeslaur/npm-library/pull/11