### PR TITLE
Add Source Repository Visibility At Signing extension

### DIFF
--- a/src/modules/x509/extensions.ts
+++ b/src/modules/x509/extensions.ts
@@ -185,4 +185,8 @@ export const EXTENSIONS_CONFIG: Record<string, ExtensionConfig> = {
 		name: "Run Invocation URI",
 		toJSON: utf8StringDecoder,
 	},
+	"1.3.6.1.4.1.57264.1.22": {
+		name: "Source Repository Visibility At Signing",
+		toJSON: utf8StringDecoder,
+	}
 };


### PR DESCRIPTION
Add config to pretty print "Source Repository Visibility At Signing" extension, e.g. https://search.sigstore.dev/?logIndex=37686387

