### PR TITLE
adding feature to allow for override of the default rekor domain on s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 ## Deploy
 
 The app is based on [Next.JS](https://nextjs.org/) and is automatically built & deployed to GitHub Pages when pushing to the `main` branch.
+
+## Internal Server Configuration
+
+This app supports overriding of the default rekor server instance for those running private instances of the the sigstore stack.
+Create a `.env.local` file at the root and include in it this environment variable
+```properties
+NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN=https://privaterekor.sigstore.dev
+```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The app is based on [Next.JS](https://nextjs.org/) and is automatically built & 
 
 This app supports overriding of the default rekor server instance for those running private instances of the the sigstore stack.
 Create a `.env.local` file at the root and include in it this environment variable
+
 ```properties
 NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN=https://privaterekor.sigstore.dev
 ```

--- a/src/modules/api/context.tsx
+++ b/src/modules/api/context.tsx
@@ -24,6 +24,12 @@ export const RekorClientProvider: FunctionComponent<PropsWithChildren<{}>> = ({
 	const [baseUrl, setBaseUrl] = useState<string>();
 
 	const context: RekorClientContext = useMemo(() => {
+		/*
+		Using the Next.js framework, the NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN env variable requires 
+		a NEXT_PUBLIC_* prefix to make the value of the variable accessible to the browser.
+		Variables missing this prefix are only accessible in the Node.js environment.
+		https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
+		*/
 		if (baseUrl === undefined && process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN) {
 			setBaseUrl(process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN)
 		}

--- a/src/modules/api/context.tsx
+++ b/src/modules/api/context.tsx
@@ -24,6 +24,10 @@ export const RekorClientProvider: FunctionComponent<PropsWithChildren<{}>> = ({
 	const [baseUrl, setBaseUrl] = useState<string>();
 
 	const context: RekorClientContext = useMemo(() => {
+		if (baseUrl === undefined && process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN) {
+			setBaseUrl(process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN)
+		}
+
 		return {
 			client: new RekorClient({ BASE: baseUrl }),
 			baseUrl,

--- a/src/modules/api/context.tsx
+++ b/src/modules/api/context.tsx
@@ -25,13 +25,13 @@ export const RekorClientProvider: FunctionComponent<PropsWithChildren<{}>> = ({
 
 	const context: RekorClientContext = useMemo(() => {
 		/*
-		Using the Next.js framework, the NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN env variable requires 
+		Using the Next.js framework, the NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN env variable requires
 		a NEXT_PUBLIC_* prefix to make the value of the variable accessible to the browser.
 		Variables missing this prefix are only accessible in the Node.js environment.
 		https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
 		*/
 		if (baseUrl === undefined && process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN) {
-			setBaseUrl(process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN)
+			setBaseUrl(process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN);
 		}
 
 		return {

--- a/src/modules/components/Settings.tsx
+++ b/src/modules/components/Settings.tsx
@@ -30,6 +30,10 @@ export function Settings({
 	}, []);
 
 	const onSave = useCallback(() => {
+		if (localBaseUrl === undefined && process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN){
+			setLocalBaseUrl(process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN);
+		}
+
 		setBaseUrl(localBaseUrl);
 		onClose();
 	}, [localBaseUrl, setBaseUrl, onClose]);
@@ -49,7 +53,7 @@ export function Settings({
 					<Typography variant="overline">Override rekor endpoint</Typography>
 					<TextField
 						value={localBaseUrl ?? ""}
-						placeholder="https://rekor.sigstore.dev"
+						placeholder= {(baseUrl === undefined) ? "https://rekor.sigstore.dev" : baseUrl}
 						onChange={handleChangeBaseUrl}
 						fullWidth
 					/>

--- a/src/modules/components/Settings.tsx
+++ b/src/modules/components/Settings.tsx
@@ -30,7 +30,10 @@ export function Settings({
 	}, []);
 
 	const onSave = useCallback(() => {
-		if (localBaseUrl === undefined && process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN){
+		if (
+			localBaseUrl === undefined &&
+			process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN
+		) {
 			setLocalBaseUrl(process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN);
 		}
 
@@ -53,7 +56,9 @@ export function Settings({
 					<Typography variant="overline">Override rekor endpoint</Typography>
 					<TextField
 						value={localBaseUrl ?? ""}
-						placeholder= {(baseUrl === undefined) ? "https://rekor.sigstore.dev" : baseUrl}
+						placeholder={
+							baseUrl === undefined ? "https://rekor.sigstore.dev" : baseUrl
+						}
 						onChange={handleChangeBaseUrl}
 						fullWidth
 					/>


### PR DESCRIPTION
…tartup of the UI

#### Summary
 Closes #51 

#### Release Note
For those running private instances of Rekor and Rekor Search UI, you can now configure a default domain at compile time as opposed to solely relying on making the change in the Settings panel post-startup.

#### Documentation
Documentation changes have been added to the README.md as the current documentation makes no reference to the rekor-search-ui

