### PR TITLE
feat(search): Implement full pagination for search results

### DIFF
--- a/src/modules/api/rekor_api.ts
+++ b/src/modules/api/rekor_api.ts
@@ -21,13 +21,13 @@ export function isAttribute(input: string): input is Attribute {
 
 export type SearchQuery =
 	| {
-		attribute: "email" | "hash" | "commitSha" | "uuid";
-		query: string;
-	}
+			attribute: "email" | "hash" | "commitSha" | "uuid";
+			query: string;
+	  }
 	| {
-		attribute: "logIndex";
-		query: number;
-	};
+			attribute: "logIndex";
+			query: number;
+	  };
 
 export interface RekorEntries {
 	totalCount: number;
@@ -59,17 +59,25 @@ export function useRekorSearch() {
 						],
 					};
 				case "email":
-					return queryEntries(client, {
-						email: search.query,
-					}, page);
+					return queryEntries(
+						client,
+						{
+							email: search.query,
+						},
+						page,
+					);
 				case "hash":
 					let query = search.query;
 					if (!query.startsWith("sha256:")) {
 						query = `sha256:${query}`;
 					}
-					return queryEntries(client, {
-						hash: query,
-					}, page);
+					return queryEntries(
+						client,
+						{
+							hash: query,
+						},
+						page,
+					);
 				case "commitSha":
 					const hash = await digestMessage(search.query);
 					return queryEntries(client, { hash }, page);

--- a/src/modules/components/Explorer.tsx
+++ b/src/modules/components/Explorer.tsx
@@ -57,20 +57,18 @@ function Error({ error }: { error: unknown }) {
 	);
 }
 
-function RekorList({ 
-	rekorEntries, 
-	page, 
-	onPageChange
-}: { 
+function RekorList({
+	rekorEntries,
+	page,
+	onPageChange,
+}: {
 	rekorEntries?: RekorEntries;
 	page: number;
 	onPageChange: (event: React.ChangeEvent<unknown>, page: number) => void;
-
- }) {
+}) {
 	if (!rekorEntries) {
 		return <></>;
 	}
-
 
 	if (rekorEntries.entries.length === 0) {
 		return (
@@ -235,7 +233,7 @@ export function Explorer() {
 			) : loading ? (
 				<LoadingIndicator />
 			) : (
-				<RekorList 
+				<RekorList
 					rekorEntries={data}
 					page={page}
 					onPageChange={handlePageChange}

--- a/src/modules/components/Explorer.tsx
+++ b/src/modules/components/Explorer.tsx
@@ -3,6 +3,7 @@ import {
 	AlertTitle,
 	Box,
 	CircularProgress,
+	Pagination,
 	Typography,
 } from "@mui/material";
 import { useRouter } from "next/router";
@@ -17,6 +18,8 @@ import {
 } from "../api/rekor_api";
 import { Entry } from "./Entry";
 import { FormInputs, SearchForm } from "./SearchForm";
+
+const PAGE_SIZE = 20;
 
 function isApiError(error: unknown): error is ApiError {
 	return !!error && typeof error === "object" && Object.hasOwn(error, "body");
@@ -54,10 +57,20 @@ function Error({ error }: { error: unknown }) {
 	);
 }
 
-function RekorList({ rekorEntries }: { rekorEntries?: RekorEntries }) {
+function RekorList({ 
+	rekorEntries, 
+	page, 
+	onPageChange
+}: { 
+	rekorEntries?: RekorEntries;
+	page: number;
+	onPageChange: (event: React.ChangeEvent<unknown>, page: number) => void;
+
+ }) {
 	if (!rekorEntries) {
 		return <></>;
 	}
+
 
 	if (rekorEntries.entries.length === 0) {
 		return (
@@ -71,10 +84,15 @@ function RekorList({ rekorEntries }: { rekorEntries?: RekorEntries }) {
 		);
 	}
 
+	const pageCount = Math.ceil(rekorEntries.totalCount / PAGE_SIZE);
+
+	const firstItem = (page - 1) * PAGE_SIZE + 1;
+	const lastItem = firstItem + rekorEntries.entries.length - 1;
+
 	return (
 		<>
 			<Typography sx={{ my: 2 }}>
-				Showing {rekorEntries.entries.length} of {rekorEntries?.totalCount}
+				Showing {firstItem} - {lastItem} of {rekorEntries.totalCount}
 			</Typography>
 
 			{rekorEntries.entries.map(entry => (
@@ -83,6 +101,19 @@ function RekorList({ rekorEntries }: { rekorEntries?: RekorEntries }) {
 					entry={entry}
 				/>
 			))}
+
+			{pageCount > 1 && (
+				<Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+					<Pagination
+						count={pageCount}
+						page={page}
+						onChange={onPageChange}
+						color="primary"
+						variant="outlined"
+						shape="rounded"
+					/>
+				</Box>
+			)}
 		</>
 	);
 }
@@ -111,6 +142,7 @@ export function Explorer() {
 	const [data, setData] = useState<RekorEntries>();
 	const [error, setError] = useState<unknown>();
 	const [loading, setLoading] = useState(false);
+	const [page, setPage] = useState(1);
 
 	useEffect(() => {
 		async function fetch() {
@@ -120,17 +152,19 @@ export function Explorer() {
 			setError(undefined);
 			setLoading(true);
 			try {
-				setData(await search(query));
+				setData(await search(query, page));
 			} catch (e) {
 				setError(e);
 			}
 			setLoading(false);
 		}
 		fetch();
-	}, [query, search]);
+	}, [query, page, search]);
 
 	const setQueryParams = useCallback(
 		(formInputs: FormInputs) => {
+			setPage(1);
+
 			router.push(
 				{
 					pathname: router.pathname,
@@ -159,6 +193,8 @@ export function Explorer() {
 
 	useEffect(() => {
 		if (formInputs) {
+			setPage(1);
+
 			switch (formInputs.attribute) {
 				case "logIndex":
 					const query = parseInt(formInputs.value);
@@ -179,6 +215,13 @@ export function Explorer() {
 		}
 	}, [formInputs]);
 
+	const handlePageChange = (
+		_event: React.ChangeEvent<unknown>,
+		newPage: number,
+	) => {
+		setPage(newPage);
+	};
+
 	return (
 		<Box>
 			<SearchForm
@@ -192,7 +235,11 @@ export function Explorer() {
 			) : loading ? (
 				<LoadingIndicator />
 			) : (
-				<RekorList rekorEntries={data} />
+				<RekorList 
+					rekorEntries={data}
+					page={page}
+					onPageChange={handlePageChange}
+				/>
 			)}
 		</Box>
 	);


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Hi, this PR introduces pagination to the Rekor search UI.

Closes #30

**Motivation:**
The Rekor Search UI correctly reported the total number of search results found, but it only ever displayed a maximum of 20 entries. As described in Issue #30, there was no mechanism for users to view results beyond the first page, preventing access to the full search dataset.

This pull request introduces a full pagination system to resolve this limitation. It also improves the overall user experience by ensuring result order is stable and the UI text is more intuitive.

**Testing Instructions:**

1. Navigate to the Rekor Search UI.
2. Perform a search query that is known to return more than 20 results.
3. Verify: A pagination control now appears at the bottom of the results list.
4. Verify: The results counter displays a range (e.g., "Showing 1 - 20 of 42").
5. Verify: Clicking on a page number or the "next" button successfully loads the next set of entries and updates the counter text correctly (e.g., "Showing 21 - 40 of 42").
6. Verify: The order of results is consistent and does not change when navigating between pages.

#### Release Note

- Added a pagination system to the Rekor Search UI, allowing users to browse all search results beyond the initial 20.
- Ensured search results have a stable, sorted order to prevent entries from changing pages between requests.
- Improved the results counter to display a clear item range (e.g., "Showing 1-20 of 42") for better usability.


#### Documentation
NONE
