### PR TITLE
feat: Support Rekor v2 tiles and HashedRekord v0.0.2

### DIFF
--- a/src/modules/api/context.tsx
+++ b/src/modules/api/context.tsx
@@ -12,6 +12,8 @@ export interface RekorClientContext {
 	client: RekorClient;
 	baseUrl?: string;
 	setBaseUrl: (base: string | undefined) => void;
+	rekorV2API: boolean;
+	setRekorV2API: (enabled: boolean) => void;
 }
 
 export const RekorClientContext = createContext<RekorClientContext | undefined>(
@@ -22,6 +24,7 @@ export const RekorClientProvider: FunctionComponent<PropsWithChildren<{}>> = ({
 	children,
 }) => {
 	const [baseUrl, setBaseUrl] = useState<string>();
+	const [rekorV2API, setRekorV2API] = useState<boolean>(false);
 
 	const context: RekorClientContext = useMemo(() => {
 		/*
@@ -38,8 +41,10 @@ export const RekorClientProvider: FunctionComponent<PropsWithChildren<{}>> = ({
 			client: new RekorClient({ BASE: baseUrl }),
 			baseUrl,
 			setBaseUrl,
+			rekorV2API,
+			setRekorV2API,
 		};
-	}, [baseUrl]);
+	}, [baseUrl, rekorV2API]);
 
 	return (
 		<RekorClientContext.Provider value={context}>
@@ -69,4 +74,17 @@ export function useRekorBaseUrl(): [
 	}
 
 	return [ctx.baseUrl, ctx.setBaseUrl];
+}
+
+export function useRekorV2API(): [
+	RekorClientContext["rekorV2API"],
+	RekorClientContext["setRekorV2API"],
+] {
+	const ctx = useContext(RekorClientContext);
+
+	if (!ctx) {
+		throw new Error("Hook useRekorV2API requires RekorClientContext.");
+	}
+
+	return [ctx.rekorV2API, ctx.setRekorV2API];
 }

--- a/src/modules/api/rekor_api.test.ts
+++ b/src/modules/api/rekor_api.test.ts
@@ -1,9 +1,11 @@
 import { renderHook } from "@testing-library/react";
 import { useRekorSearch } from "./rekor_api";
-import { useRekorClient } from "./context";
+import { useRekorBaseUrl, useRekorClient, useRekorV2API } from "./context";
 
 jest.mock("./context", () => ({
 	useRekorClient: jest.fn(),
+	useRekorBaseUrl: jest.fn(),
+	useRekorV2API: jest.fn(),
 }));
 
 Object.defineProperty(global.self, "crypto", {
@@ -26,6 +28,11 @@ describe("useRekorSearch", () => {
 		(useRekorClient as jest.Mock).mockReturnValue({
 			entries: { getLogEntryByIndex: mockGetLogEntryByIndex },
 		});
+		(useRekorBaseUrl as jest.Mock).mockReturnValue([
+			"http://localhost",
+			jest.fn(),
+		]);
+		(useRekorV2API as jest.Mock).mockReturnValue([false, jest.fn()]);
 
 		const { result } = renderHook(() => useRekorSearch());
 

--- a/src/modules/api/rekor_api.ts
+++ b/src/modules/api/rekor_api.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { LogEntry, RekorClient, SearchIndex } from "rekor";
-import { useRekorClient } from "./context";
+import { useRekorBaseUrl, useRekorClient, useRekorV2API } from "./context";
+import { getRekorTileEntryByIndex } from "./tiles";
 
 const PAGE_SIZE = 20;
 
@@ -36,11 +37,19 @@ export interface RekorEntries {
 
 export function useRekorSearch() {
 	const client = useRekorClient();
+	const [baseUrl] = useRekorBaseUrl();
+	const [rekorV2API] = useRekorV2API();
 
 	return useCallback(
 		async (search: SearchQuery, page: number = 1): Promise<RekorEntries> => {
 			switch (search.attribute) {
 				case "logIndex":
+					if (rekorV2API) {
+						return {
+							totalCount: 1,
+							entries: [await getRekorTileEntryByIndex(baseUrl, search.query)],
+						};
+					}
 					return {
 						totalCount: 1,
 						entries: [
@@ -83,7 +92,7 @@ export function useRekorSearch() {
 					return queryEntries(client, { hash }, page);
 			}
 		},
-		[client],
+		[client, baseUrl, rekorV2API],
 	);
 }
 

--- a/src/modules/api/tiles.test.ts
+++ b/src/modules/api/tiles.test.ts
@@ -1,0 +1,67 @@
+import { formatTileIndex, getRekorTileEntryByIndex } from "./tiles";
+
+describe("tiles API", () => {
+	it("formatTileIndex correctly formats indexes", () => {
+		expect(formatTileIndex(0)).toBe("000");
+		expect(formatTileIndex(1)).toBe("001");
+		expect(formatTileIndex(256)).toBe("256");
+		expect(formatTileIndex(1000)).toBe("x001/000");
+		expect(formatTileIndex(1234067)).toBe("x001/x234/067");
+	});
+
+	it("getRekorTileEntryByIndex fetches and parses entry correctly", async () => {
+		// Mock fetch to return a binary bundle.
+		// Tile index 0 contains 2 mock entries for testing.
+		// Entry 0: length 4 (0x0004), data: "abcd"
+		// Entry 1: length 5 (0x0005), data: "efghi"
+
+		const buffer = new ArrayBuffer(2 + 4 + 2 + 5);
+		const dataView = new DataView(buffer);
+
+		let offset = 0;
+		// Entry 0
+		dataView.setUint16(offset, 4, false); // length
+		offset += 2;
+		const entry1 = "abcd";
+		for (let i = 0; i < entry1.length; i++) {
+			dataView.setUint8(offset++, entry1.charCodeAt(i));
+		}
+
+		// Entry 1
+		dataView.setUint16(offset, 5, false); // length
+		offset += 2;
+		const entry2 = "efghi";
+		for (let i = 0; i < entry2.length; i++) {
+			dataView.setUint8(offset++, entry2.charCodeAt(i));
+		}
+
+		// Mock fetch
+		global.fetch = jest.fn((url: string) => {
+			if (url.endsWith("/checkpoint")) {
+				return Promise.resolve({
+					ok: true,
+					text: () =>
+						Promise.resolve("example.com/log\n1000\nrootHashRawBase64"),
+				});
+			} else {
+				return Promise.resolve({
+					ok: true,
+					arrayBuffer: () => Promise.resolve(buffer),
+				});
+			}
+		}) as jest.Mock;
+
+		// Fetch logIndex = 1 (which falls into tile 0, entry index 1)
+		const logEntry = await getRekorTileEntryByIndex("http://example.com", 1);
+
+		const firstKey = Object.keys(logEntry)[0];
+		expect(logEntry[firstKey].body).toBe(btoa("efghi"));
+		expect(logEntry[firstKey].integratedTime).toBe(0);
+		expect(logEntry[firstKey].logIndex).toBe(1);
+
+		expect(global.fetch).toHaveBeenCalledWith("http://example.com/checkpoint");
+		expect(global.fetch).toHaveBeenCalledWith(
+			"http://example.com/tile/entries/000",
+		);
+	});
+});

--- a/src/modules/api/tiles.ts
+++ b/src/modules/api/tiles.ts
@@ -1,0 +1,103 @@
+import { LogEntry } from "rekor";
+
+export function formatTileIndex(tileIndex: number): string {
+	let s = tileIndex.toString();
+	// Pad to multiple of 3 digits
+	while (s.length % 3 !== 0) {
+		s = "0" + s;
+	}
+	const parts = [];
+	for (let i = 0; i < s.length; i += 3) {
+		parts.push(s.slice(i, i + 3));
+	}
+	for (let i = 0; i < parts.length - 1; i++) {
+		parts[i] = "x" + parts[i];
+	}
+	return parts.join("/");
+}
+
+export async function getRekorTileEntryByIndex(
+	baseUrl: string | undefined,
+	logIndex: number,
+): Promise<LogEntry> {
+	if (!baseUrl) {
+		throw new Error(
+			"A custom override URL is required for the Rekor v2 API. Please configure one in Settings.",
+		);
+	}
+	const base = baseUrl;
+	const tileIndex = Math.floor(logIndex / 256);
+	const entryIndexInTile = logIndex % 256;
+
+	const tilePath = formatTileIndex(tileIndex);
+	let url = `${base}/tile/entries/${tilePath}`;
+
+	// In the C2SP tlog specification, the tail of the log is represented by "partial" tiles.
+	// A partial tile is served with a `.p/W` suffix where W is the number of elements in the tile.
+	// We always fetch the checkpoint first to find the exact tree size and reconstruct the URL to avoid 404s.
+	const cpResponse = await fetch(`${base}/checkpoint`);
+	if (!cpResponse.ok) {
+		throw new Error(`Failed to fetch checkpoint: ${cpResponse.statusText}`);
+	}
+	const cpText = await cpResponse.text();
+	const lines = cpText.split("\n");
+	if (lines.length < 2) {
+		throw new Error("Invalid checkpoint format");
+	}
+
+	const treeSize = parseInt(lines[1], 10);
+	if (logIndex >= treeSize) {
+		throw new Error(
+			`Log index ${logIndex} is out of bounds (Tree size: ${treeSize})`,
+		);
+	}
+
+	const fullTilesCount = Math.floor(treeSize / 256);
+	if (tileIndex === fullTilesCount) {
+		const partialWidth = treeSize % 256;
+		if (partialWidth > 0) {
+			url = `${base}/tile/entries/${tilePath}.p/${partialWidth}`;
+		}
+	}
+
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(
+			`Failed to fetch rekor-tiles bundle: ${response.statusText} (${response.status}) at ${url}`,
+		);
+	}
+
+	const buffer = await response.arrayBuffer();
+	const dataView = new DataView(buffer);
+
+	let offset = 0;
+	for (let i = 0; i <= entryIndexInTile; i++) {
+		if (offset >= buffer.byteLength) {
+			throw new Error("Entry out of bounds in tile");
+		}
+		const length = dataView.getUint16(offset, false); // false = big-endian
+		offset += 2;
+
+		if (i === entryIndexInTile) {
+			const entryBytes = new Uint8Array(buffer, offset, length);
+			const entryStr = new TextDecoder().decode(entryBytes);
+
+			// Wrap in a mock LogEntry object to align with Rekor API shape
+			// We use a mock UUID since tile API doesn't return UUIDs
+			const mockUuid =
+				"0000000000000000000000000000000000000000000000000000000000000000";
+
+			return {
+				[mockUuid]: {
+					body: btoa(entryStr),
+					logIndex: logIndex,
+					integratedTime: 0, // Fallback to epoch 0 to signify "unsupported"
+				},
+			} as any;
+		}
+
+		offset += length;
+	}
+
+	throw new Error("Entry not found in tile");
+}

--- a/src/modules/components/Entry.test.tsx
+++ b/src/modules/components/Entry.test.tsx
@@ -4,6 +4,7 @@ jest.mock("../utils/date", () => ({
 }));
 jest.mock("./HashedRekord", () => ({
 	HashedRekordViewer: () => <div>MockedHashedRekordViewer</div>,
+	HashedRekordV002Viewer: () => <div>MockedHashedRekordV002Viewer</div>,
 }));
 
 import atobMock from "../../__mocks__/atobMock";

--- a/src/modules/components/Entry.tsx
+++ b/src/modules/components/Entry.tsx
@@ -27,7 +27,7 @@ import {
 } from "rekor";
 import { toRelativeDateString } from "../utils/date";
 import { DSSEViewer } from "./DSSE";
-import { HashedRekordViewer } from "./HashedRekord";
+import { HashedRekordViewer, HashedRekordV002Viewer } from "./HashedRekord";
 import { IntotoViewer001 } from "./Intoto001";
 import { IntotoViewer002 } from "./Intoto002";
 
@@ -136,7 +136,11 @@ export function Entry({ entry }: { entry: LogEntry }) {
 	let parsed: ReactNode | undefined;
 	switch (body.kind) {
 		case "hashedrekord":
-			parsed = <HashedRekordViewer hashedRekord={body.spec as RekorSchema} />;
+			if (body.apiVersion === "0.0.1") {
+				parsed = <HashedRekordViewer hashedRekord={body.spec as RekorSchema} />;
+			} else {
+				parsed = <HashedRekordV002Viewer hashedRekord={body.spec as any} />;
+			}
 			break;
 		case "intoto":
 			if (body.apiVersion == "0.0.1") {
@@ -153,27 +157,32 @@ export function Entry({ entry }: { entry: LogEntry }) {
 
 	return (
 		<Paper sx={{ mb: 2, p: 1 }}>
-			<Typography
-				variant="h5"
-				component="h2"
-				sx={{
-					overflow: "hidden",
-					textOverflow: "ellipsis",
-				}}
-			>
-				Entry UUID:{" "}
-				<Link
-					component={NextLink}
-					href={`/?uuid=${uuid}`}
-					passHref
-				>
-					{uuid}
-				</Link>
-			</Typography>
-			<Divider
-				flexItem
-				sx={{ my: 1 }}
-			/>
+			{uuid !==
+				"0000000000000000000000000000000000000000000000000000000000000000" && (
+				<>
+					<Typography
+						variant="h5"
+						component="h2"
+						sx={{
+							overflow: "hidden",
+							textOverflow: "ellipsis",
+						}}
+					>
+						Entry UUID:{" "}
+						<Link
+							component={NextLink}
+							href={`/?uuid=${uuid}`}
+							passHref
+						>
+							{uuid}
+						</Link>
+					</Typography>
+					<Divider
+						flexItem
+						sx={{ my: 1 }}
+					/>
+				</>
+			)}
 			<Grid
 				container
 				sx={{ mb: 1 }}
@@ -217,7 +226,11 @@ export function Entry({ entry }: { entry: LogEntry }) {
 				>
 					<Card
 						title="Integrated time"
-						content={toRelativeDateString(new Date(obj.integratedTime * 1000))}
+						content={
+							obj.integratedTime === 0
+								? "Unsupported"
+								: toRelativeDateString(new Date(obj.integratedTime * 1000))
+						}
 						dividerSx={{
 							display: {
 								xs: "none",

--- a/src/modules/components/Explorer.tsx
+++ b/src/modules/components/Explorer.tsx
@@ -16,6 +16,7 @@ import {
 	SearchQuery,
 	useRekorSearch,
 } from "../api/rekor_api";
+import { useRekorBaseUrl, useRekorV2API } from "../api/context";
 import { Entry } from "./Entry";
 import { FormInputs, SearchForm } from "./SearchForm";
 
@@ -38,11 +39,11 @@ function Error({ error }: { error: unknown }) {
 			title = `Code ${error.body.code}: ${error.body.message}`;
 		}
 		detail = `${error.url}: ${error.status}`;
-	} else if (typeof error == "string") {
+	} else if (error instanceof Error) {
+		title = (error as Error).message;
+		detail = (error as Error).stack;
+	} else if (typeof error === "string") {
 		title = error;
-	} else if (error instanceof TypeError) {
-		title = error.message;
-		detail = error.stack;
 	}
 
 	return (
@@ -137,6 +138,9 @@ export function Explorer() {
 	const [query, setQuery] = useState<SearchQuery>();
 	const search = useRekorSearch();
 
+	const [baseUrl, setBaseUrl] = useRekorBaseUrl();
+	const [rekorV2API, setRekorV2API] = useRekorV2API();
+
 	const [data, setData] = useState<RekorEntries>();
 	const [error, setError] = useState<unknown>();
 	const [loading, setLoading] = useState(false);
@@ -163,21 +167,45 @@ export function Explorer() {
 		(formInputs: FormInputs) => {
 			setPage(1);
 
+			const queryConfig: Record<string, string> = {
+				[formInputs.attribute]: formInputs.value,
+			};
+			let urlString = `/?${formInputs.attribute}=${formInputs.value}`;
+
+			if (rekorV2API) {
+				queryConfig["rekorV2"] = "true";
+				urlString += `&rekorV2=true`;
+			}
+			if (baseUrl) {
+				queryConfig["rekorUrl"] = baseUrl;
+				urlString += `&rekorUrl=${encodeURIComponent(baseUrl)}`;
+			}
+
 			router.push(
 				{
 					pathname: router.pathname,
-					query: {
-						[formInputs.attribute]: formInputs.value,
-					},
+					query: queryConfig,
 				},
-				`/?${formInputs.attribute}=${formInputs.value}`,
+				urlString,
 				{ shallow: true },
 			);
 		},
-		[router],
+		[router, rekorV2API, baseUrl],
 	);
 
 	useEffect(() => {
+		const rekorV2Query = router.query["rekorV2"];
+		if (rekorV2Query === "true") {
+			setRekorV2API(true);
+		} else if (rekorV2Query === "false") {
+			setRekorV2API(false);
+		}
+
+		const rekorUrlQuery = router.query["rekorUrl"];
+		if (typeof rekorUrlQuery === "string") {
+			setBaseUrl(rekorUrlQuery);
+		}
+
 		const attribute = Object.keys(router.query).find(key =>
 			isAttribute(key),
 		) as Attribute | undefined;

--- a/src/modules/components/HashedRekord.test.tsx
+++ b/src/modules/components/HashedRekord.test.tsx
@@ -58,3 +58,69 @@ describe("HashedRekordViewer", () => {
 		).toBeInTheDocument();
 	});
 });
+
+import { HashedRekordV002Viewer } from "./HashedRekord";
+
+describe("HashedRekordV002Viewer", () => {
+	it("renders the component bridging a full oneOf snake_case spec payload", () => {
+		const fakeHex = "a".repeat(64);
+		const mockedV002SnakeCase = {
+			hashed_rekord_v002: {
+				data: {
+					hash: {
+						algorithm: "sha256",
+						value: fakeHex,
+					},
+				},
+				signature: {
+					content: "mockedV002SignatureContent",
+					verifier: {
+						public_key: {
+							raw_bytes: window.btoa("mockedV002PublicKeyBytes"),
+						},
+					},
+				},
+			},
+		};
+
+		render(<HashedRekordV002Viewer hashedRekord={mockedV002SnakeCase} />);
+
+		expect(screen.getByText("Hash")).toBeInTheDocument();
+		expect(screen.getByText(`sha256:${fakeHex}`)).toBeInTheDocument();
+		expect(screen.getByText("mockedV002SignatureContent")).toBeInTheDocument();
+		expect(screen.getByText("Public Key")).toBeInTheDocument();
+		expect(
+			screen.getByText(/bW9ja2VkVjAwMlB1YmxpY0tleUJ5dGVz/),
+		).toBeInTheDocument(); // raw base64 rendered within BEGIN/END PUBLIC KEY tags
+	});
+
+	it("renders the component with a generated valid PEM wrapping for raw binary certificates", () => {
+		const mockedFlatCert = {
+			data: {
+				digest: window.btoa("hexValueDigestRaw"),
+			},
+			signature: {
+				content: "flatSigContent",
+			},
+			verifier: {
+				x509Certificate: {
+					rawBytes: window.btoa("derBinaryBytes"),
+				},
+			},
+		};
+
+		render(<HashedRekordV002Viewer hashedRekord={mockedFlatCert} />);
+
+		// Verify digest parses correctly
+		expect(screen.getByText("flatSigContent")).toBeInTheDocument();
+
+		// Ensure it hits our decoding logic branch mocked out in decodex509Mock
+		// (which by default injects the phrase 'Mocked Certificate' into the dumped JSON strings in the test)
+		expect(
+			screen.getByText(
+				/'-----BEGIN CERTIFICATE-----Mocked Certificate-----END CERTIFICATE-----'/,
+			),
+		).toBeInTheDocument();
+		expect(screen.getByText("Public Key Certificate")).toBeInTheDocument();
+	});
+});

--- a/src/modules/components/HashedRekord.tsx
+++ b/src/modules/components/HashedRekord.tsx
@@ -76,3 +76,173 @@ export function HashedRekordViewer({
 		</Box>
 	);
 }
+
+export function HashedRekordV002Viewer({
+	hashedRekord,
+}: {
+	hashedRekord: any;
+}) {
+	let actualRekord = hashedRekord;
+	if (
+		actualRekord &&
+		typeof actualRekord === "object" &&
+		!actualRekord.data &&
+		!actualRekord.Data &&
+		!actualRekord.signature &&
+		!actualRekord.Signature
+	) {
+		const keys = Object.keys(actualRekord);
+		if (keys.length === 1 && typeof actualRekord[keys[0]] === "object") {
+			actualRekord = actualRekord[keys[0]];
+		}
+	}
+
+	const sig = actualRekord?.signature || actualRekord?.Signature;
+	const verifier =
+		sig?.verifier ||
+		sig?.Verifier ||
+		actualRekord.verifier ||
+		actualRekord.Verifier;
+
+	const rawKey =
+		verifier?.publicKey?.rawBytes ||
+		verifier?.public_key?.raw_bytes ||
+		verifier?.PublicKey?.RawBytes ||
+		verifier?.x509Certificate?.rawBytes ||
+		verifier?.x509_certificate?.raw_bytes ||
+		verifier?.X509Certificate?.RawBytes ||
+		verifier?.publicKey?.content ||
+		verifier?.PublicKey?.Content ||
+		verifier?.publicKey ||
+		verifier?.PublicKey ||
+		verifier?.x509Certificate ||
+		verifier?.X509Certificate ||
+		"";
+
+	const isCert = !!(
+		verifier?.x509Certificate ||
+		verifier?.x509_certificate ||
+		verifier?.X509Certificate
+	);
+
+	let certContent = "";
+	if (rawKey) {
+		try {
+			if (
+				rawKey.includes("BEGIN CERTIFICATE") ||
+				rawKey.includes("BEGIN PUBLIC KEY")
+			) {
+				certContent = rawKey;
+			} else if (isCert) {
+				const formatted = rawKey.replace(/(.{64})/g, "$1\n");
+				certContent = `-----BEGIN CERTIFICATE-----\n${formatted.trim()}\n-----END CERTIFICATE-----\n`;
+			} else {
+				// Assume raw public key
+				const formatted = rawKey.replace(/(.{64})/g, "$1\n");
+				certContent = `-----BEGIN PUBLIC KEY-----\n${formatted.trim()}\n-----END PUBLIC KEY-----\n`;
+			}
+		} catch (e) {
+			certContent = rawKey;
+		}
+	}
+
+	const publicKey = {
+		title: isCert ? "Public Key Certificate" : "Public Key",
+		content: certContent,
+	};
+
+	if (certContent.includes("BEGIN CERTIFICATE")) {
+		try {
+			publicKey.content = dump(decodex509(certContent), {
+				noArrayIndent: true,
+				lineWidth: -1,
+			});
+		} catch {
+			// If decodex509 fails, fallback to rendering the PEM contents
+		}
+	}
+
+	let hexDigest = "";
+	const data = actualRekord.data || actualRekord.Data || {};
+	const payloadDigest =
+		data?.hash?.value ||
+		data?.Hash?.Value ||
+		data?.digest ||
+		data?.Digest ||
+		"";
+
+	if (payloadDigest) {
+		if (/^[0-9a-fA-F]+$/.test(payloadDigest) && payloadDigest.length >= 40) {
+			hexDigest = payloadDigest;
+		} else {
+			try {
+				const rawDigest = window.atob(payloadDigest);
+				for (let i = 0; i < rawDigest.length; i++) {
+					hexDigest += rawDigest.charCodeAt(i).toString(16).padStart(2, "0");
+				}
+			} catch (e) {
+				hexDigest = payloadDigest;
+			}
+		}
+	}
+
+	const algorithm = (
+		data?.hash?.algorithm ||
+		data?.Hash?.Algorithm ||
+		data?.algorithm ||
+		data?.Algorithm ||
+		""
+	).toLowerCase();
+
+	const sigContent =
+		sig?.content || sig?.Content || (typeof sig === "string" ? sig : "");
+
+	return (
+		<Box>
+			<Typography
+				variant="h5"
+				sx={{ py: 1 }}
+			>
+				<Link
+					component={NextLink}
+					href={`/?hash=${algorithm}:${hexDigest}`}
+					passHref
+				>
+					Hash
+				</Link>
+			</Typography>
+
+			<SyntaxHighlighter
+				language="text"
+				style={atomDark}
+			>
+				{`${algorithm}:${hexDigest}`}
+			</SyntaxHighlighter>
+
+			<Typography
+				variant="h5"
+				sx={{ py: 1 }}
+			>
+				Signature
+			</Typography>
+			<SyntaxHighlighter
+				language="text"
+				style={atomDark}
+			>
+				{sigContent}
+			</SyntaxHighlighter>
+			<Typography
+				variant="h5"
+				sx={{ py: 1 }}
+			>
+				{publicKey.title}
+			</Typography>
+			<SyntaxHighlighter
+				language="yaml"
+				style={atomDark}
+			>
+				{publicKey.content}
+			</SyntaxHighlighter>
+		</Box>
+	);
+}

--- a/src/modules/components/SearchForm.tsx
+++ b/src/modules/components/SearchForm.tsx
@@ -10,6 +10,7 @@ import {
 import Paper from "@mui/material/Paper";
 import { ReactNode, useEffect } from "react";
 import { Controller, RegisterOptions, useForm } from "react-hook-form";
+import { useRekorV2API } from "../api/context";
 import { Attribute, ATTRIBUTES } from "../api/rekor_api";
 
 export interface FormProps {
@@ -124,6 +125,17 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 	}, [defaultValues, setValue]);
 
 	const watchAttribute = watch("attribute");
+	const [rekorV2API] = useRekorV2API();
+
+	useEffect(() => {
+		if (rekorV2API && watchAttribute !== "logIndex") {
+			setValue("attribute", "logIndex");
+		}
+	}, [rekorV2API, watchAttribute, setValue]);
+
+	const availableAttributes = rekorV2API
+		? ATTRIBUTES.filter(attr => attr === "logIndex")
+		: ATTRIBUTES;
 
 	useEffect(() => {
 		if (control.getFieldState("attribute").isTouched) {
@@ -172,7 +184,7 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 										{...field}
 										label="Attribute"
 									>
-										{ATTRIBUTES.map(attribute => (
+										{availableAttributes.map(attribute => (
 											<MenuItem
 												key={attribute}
 												value={attribute}

--- a/src/modules/components/Settings.test.tsx
+++ b/src/modules/components/Settings.test.tsx
@@ -1,5 +1,6 @@
 jest.mock("../api/context", () => ({
 	useRekorBaseUrl: jest.fn(),
+	useRekorV2API: jest.fn(),
 }));
 
 jest.mock("next/config", () => () => ({
@@ -10,7 +11,7 @@ jest.mock("next/config", () => () => ({
 
 import { render, screen } from "@testing-library/react";
 import { Settings } from "./Settings";
-import { useRekorBaseUrl } from "../api/context";
+import { useRekorBaseUrl, useRekorV2API } from "../api/context";
 
 describe("Settings Component", () => {
 	const mockOnClose = jest.fn();
@@ -23,6 +24,7 @@ describe("Settings Component", () => {
 			"https://initial.rekor.domain",
 			mockSetBaseUrl,
 		]);
+		(useRekorV2API as jest.Mock).mockReturnValue([false, jest.fn()]);
 	});
 
 	afterEach(() => {

--- a/src/modules/components/Settings.tsx
+++ b/src/modules/components/Settings.tsx
@@ -1,13 +1,16 @@
 import {
 	Box,
 	Button,
+	Checkbox,
 	Divider,
 	Drawer,
+	FormControlLabel,
 	TextField,
 	Typography,
 } from "@mui/material";
-import { ChangeEventHandler, useCallback, useState } from "react";
-import { useRekorBaseUrl } from "../api/context";
+import { ChangeEventHandler, useCallback, useState, useEffect } from "react";
+import { useRouter } from "next/router";
+import { useRekorBaseUrl, useRekorV2API } from "../api/context";
 
 export function Settings({
 	open,
@@ -18,6 +21,19 @@ export function Settings({
 }) {
 	const [baseUrl, setBaseUrl] = useRekorBaseUrl();
 	const [localBaseUrl, setLocalBaseUrl] = useState(baseUrl);
+
+	useEffect(() => {
+		setLocalBaseUrl(baseUrl);
+	}, [baseUrl]);
+
+	const [rekorV2API, setRekorV2API] = useRekorV2API();
+	const [localRekorV2API, setLocalRekorV2API] = useState(rekorV2API);
+
+	useEffect(() => {
+		setLocalRekorV2API(rekorV2API);
+	}, [rekorV2API]);
+
+	const router = useRouter();
 
 	const handleChangeBaseUrl: ChangeEventHandler<
 		HTMLTextAreaElement | HTMLInputElement
@@ -32,14 +48,45 @@ export function Settings({
 	const onSave = useCallback(() => {
 		if (
 			localBaseUrl === undefined &&
-			process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN
+			process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN &&
+			!localRekorV2API
 		) {
 			setLocalBaseUrl(process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN);
 		}
 
 		setBaseUrl(localBaseUrl);
+		setRekorV2API(localRekorV2API);
+
+		const newQuery = { ...router.query };
+		if (localRekorV2API) {
+			newQuery["rekorV2"] = "true";
+		} else {
+			delete newQuery["rekorV2"];
+		}
+		if (localBaseUrl) {
+			newQuery["rekorUrl"] = localBaseUrl;
+		} else {
+			delete newQuery["rekorUrl"];
+		}
+
+		router.push(
+			{
+				pathname: router.pathname,
+				query: newQuery,
+			},
+			undefined,
+			{ shallow: true },
+		);
+
 		onClose();
-	}, [localBaseUrl, setBaseUrl, onClose]);
+	}, [
+		localBaseUrl,
+		localRekorV2API,
+		setBaseUrl,
+		setRekorV2API,
+		onClose,
+		router,
+	]);
 
 	return (
 		<Drawer
@@ -53,11 +100,27 @@ export function Settings({
 				</Box>
 				<Divider />
 				<Box sx={{ p: 2 }}>
+					<FormControlLabel
+						control={
+							<Checkbox
+								checked={localRekorV2API}
+								onChange={e => setLocalRekorV2API(e.target.checked)}
+							/>
+						}
+						label="Rekor v2 API"
+					/>
+				</Box>
+				<Divider />
+				<Box sx={{ p: 2 }}>
 					<Typography variant="overline">Override rekor endpoint</Typography>
 					<TextField
 						value={localBaseUrl ?? ""}
 						placeholder={
-							baseUrl === undefined ? "https://rekor.sigstore.dev" : baseUrl
+							baseUrl === undefined
+								? localRekorV2API
+									? "e.g., https://log2025-1.rekor.sigstore.dev/api/v2"
+									: "https://rekor.sigstore.dev"
+								: baseUrl
 						}
 						onChange={handleChangeBaseUrl}
 						fullWidth

--- a/src/modules/x509/extensions.ts
+++ b/src/modules/x509/extensions.ts
@@ -63,7 +63,9 @@ export const EXTENSIONS_CONFIG: Record<string, ExtensionConfig> = {
 	"2.5.29.17": {
 		name: "Subject Alternative Name",
 		toJSON(rawExtension: Extension) {
-			return new SubjectAlternativeNameExtension(rawExtension.rawData).toJSON();
+			return new SubjectAlternativeNameExtension(
+				rawExtension.rawData,
+			).names.toJSON();
 		},
 	},
 	"2.5.29.19": {


### PR DESCRIPTION
* Fetch entries dynamically from a C2SP tile-based tlog
* Added settings overrides and URL parameters for togging Rekor v2 contexts
* Added HashedRekord002Viewer to handle new spec schema. In trying to minimize the number of changes, all certs are PEM-wrapped to use the same parsing logic
* Various UI cleanups to deal with v1 vs v2 differences, e.g. no entry UUID, no integrated timestamp

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
