### PR TITLE
search: add Subject (SAN) attribute

### DIFF
--- a/src/modules/api/rekor_api.test.ts
+++ b/src/modules/api/rekor_api.test.ts
@@ -33,4 +33,23 @@ describe("useRekorSearch", () => {
 
 		expect(mockGetLogEntryByIndex).toHaveBeenCalledWith({ logIndex: 123 });
 	});
+
+	it("searches by subject (SAN URI)", async () => {
+		const mockSearchIndex = jest.fn().mockResolvedValue([]);
+
+		(useRekorClient as jest.Mock).mockReturnValue({
+			index: { searchIndex: mockSearchIndex },
+			entries: { getLogEntryByUuid: jest.fn() },
+		});
+
+		const { result } = renderHook(() => useRekorSearch());
+
+		const sanURI =
+			"https://github.com/owner/repo/.github/workflows/build.yml@refs/heads/main";
+		await result.current({ attribute: "subject", query: sanURI });
+
+		expect(mockSearchIndex).toHaveBeenCalledWith({
+			query: { subject: sanURI },
+		});
+	});
 });

--- a/src/modules/api/rekor_api.ts
+++ b/src/modules/api/rekor_api.ts
@@ -1,5 +1,9 @@
 import { useCallback } from "react";
-import { LogEntry, RekorClient, SearchIndex as UpstreamSearchIndex } from "rekor";
+import {
+	LogEntry,
+	RekorClient,
+	SearchIndex as UpstreamSearchIndex,
+} from "rekor";
 import { useRekorClient } from "./context";
 
 type SearchIndex = UpstreamSearchIndex & { subject?: string };

--- a/src/modules/api/rekor_api.ts
+++ b/src/modules/api/rekor_api.ts
@@ -1,11 +1,14 @@
 import { useCallback } from "react";
-import { LogEntry, RekorClient, SearchIndex } from "rekor";
+import { LogEntry, RekorClient, SearchIndex as UpstreamSearchIndex } from "rekor";
 import { useRekorClient } from "./context";
+
+type SearchIndex = UpstreamSearchIndex & { subject?: string };
 
 const PAGE_SIZE = 20;
 
 export const ATTRIBUTES = [
 	"email",
+	"subject",
 	"hash",
 	"commitSha",
 	"uuid",
@@ -21,7 +24,7 @@ export function isAttribute(input: string): input is Attribute {
 
 export type SearchQuery =
 	| {
-			attribute: "email" | "hash" | "commitSha" | "uuid";
+			attribute: "email" | "subject" | "hash" | "commitSha" | "uuid";
 			query: string;
 	  }
 	| {
@@ -66,6 +69,14 @@ export function useRekorSearch() {
 						},
 						page,
 					);
+				case "subject":
+					return queryEntries(
+						client,
+						{
+							subject: search.query,
+						},
+						page,
+					);
 				case "hash":
 					let query = search.query;
 					if (!query.startsWith("sha256:")) {
@@ -92,7 +103,9 @@ async function queryEntries(
 	query: SearchIndex,
 	page: number,
 ): Promise<RekorEntries> {
-	const logIndexes = await client.index.searchIndex({ query });
+	const logIndexes = await client.index.searchIndex({
+		query: query as UpstreamSearchIndex,
+	});
 
 	// Preventing entries from jumping between pages on refresh
 	logIndexes.sort();

--- a/src/modules/components/SearchForm.test.tsx
+++ b/src/modules/components/SearchForm.test.tsx
@@ -19,4 +19,22 @@ describe("SearchForm", () => {
 		expect(screen.getByRole("textbox", { name: /email/i })).toHaveValue("");
 		expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
 	});
+
+	it("renders the Subject (SAN) input when subject is the active attribute", () => {
+		const sanURI =
+			"https://github.com/owner/repo/.github/workflows/build.yml@refs/heads/main";
+		render(
+			<RekorClientProvider>
+				<SearchForm
+					defaultValues={{ attribute: "subject", value: sanURI }}
+					isLoading={false}
+					onSubmit={jest.fn()}
+				/>
+			</RekorClientProvider>,
+		);
+
+		const input = screen.getByRole("textbox", { name: /subject \(san\)/i });
+		expect(input).toBeInTheDocument();
+		expect(input).toHaveValue(sanURI);
+	});
 });

--- a/src/modules/components/SearchForm.tsx
+++ b/src/modules/components/SearchForm.tsx
@@ -44,6 +44,25 @@ const inputConfigByAttribute: Record<FormInputs["attribute"], InputConfig> = {
 			},
 		},
 	},
+	subject: {
+		name: "Subject (SAN)",
+		helperText: (
+			<>
+				Subject Alternative Name on the signing cert — e.g. a GitHub OIDC URI
+				such as{" "}
+				<code>
+					https://github.com/owner/repo/.github/workflows/build.yml@refs/heads/main
+				</code>
+				. Lookup is case-insensitive.
+			</>
+		),
+		rules: {
+			maxLength: {
+				value: 2048,
+				message: "Subject must be 2048 characters or fewer",
+			},
+		},
+	},
 	hash: {
 		name: "Hash",
 		rules: {

--- a/src/modules/x509/extensions.test.ts
+++ b/src/modules/x509/extensions.test.ts
@@ -14,7 +14,9 @@ describe("EXTENSIONS_CONFIG['2.5.29.17']", () => {
 
 		const out = EXTENSIONS_CONFIG["2.5.29.17"].toJSON({
 			rawData: built.rawData,
-		} as unknown as Parameters<typeof EXTENSIONS_CONFIG[string]["toJSON"]>[0]);
+		} as unknown as Parameters<
+			(typeof EXTENSIONS_CONFIG)[string]["toJSON"]
+		>[0]);
 
 		expect(out).toEqual([
 			{

--- a/src/modules/x509/extensions.test.ts
+++ b/src/modules/x509/extensions.test.ts
@@ -1,0 +1,28 @@
+import { SubjectAlternativeNameExtension } from "@peculiar/x509";
+import { EXTENSIONS_CONFIG } from "./extensions";
+
+describe("EXTENSIONS_CONFIG['2.5.29.17']", () => {
+	it("projects SAN GeneralNames into {type, value} entries", () => {
+		const built = new SubjectAlternativeNameExtension([
+			{
+				type: "url",
+				value:
+					"https://github.com/owner/repo/.github/workflows/build.yml@refs/heads/main",
+			},
+			{ type: "dns", value: "foo.example" },
+		]);
+
+		const out = EXTENSIONS_CONFIG["2.5.29.17"].toJSON({
+			rawData: built.rawData,
+		} as unknown as Parameters<typeof EXTENSIONS_CONFIG[string]["toJSON"]>[0]);
+
+		expect(out).toEqual([
+			{
+				type: "url",
+				value:
+					"https://github.com/owner/repo/.github/workflows/build.yml@refs/heads/main",
+			},
+			{ type: "dns", value: "foo.example" },
+		]);
+	});
+});

--- a/src/modules/x509/extensions.ts
+++ b/src/modules/x509/extensions.ts
@@ -63,7 +63,9 @@ export const EXTENSIONS_CONFIG: Record<string, ExtensionConfig> = {
 	"2.5.29.17": {
 		name: "Subject Alternative Name",
 		toJSON(rawExtension: Extension) {
-			return new SubjectAlternativeNameExtension(rawExtension.rawData).toJSON();
+			return new SubjectAlternativeNameExtension(
+				rawExtension.rawData,
+			).names.items.map(name => ({ type: name.type, value: name.value }));
 		},
 	},
 	"2.5.29.19": {


### PR DESCRIPTION
## Summary

- Adds a "Subject (SAN)" option to the search dropdown, enabling lookup by SAN values (URI, DNS, etc.) on the signing cert — e.g. GitHub OIDC URIs like `https://github.com/owner/repo/.github/workflows/build.yml@refs/heads/main`.
- Wires the new `subject` field on `/api/v1/index/retrieve` (server-side: sigstore/rekor#2850).
- Fixes pre-existing crash rendering Fulcio certs: `@peculiar/x509` removed `SubjectAlternativeNameExtension.toJSON()`; now projects `GeneralNames.items` directly.

## Test plan

- [x] Unit: search hook passes `{ subject: <URI> }` to the index service
- [x] Unit: Subject (SAN) input renders with correct label and value
- [x] Unit: SAN extension decoder round-trips URI + DNS entries
- [x] Smoke-tested against local rekor-server docker-compose stack